### PR TITLE
test coverage; credo/dogma fixes

### DIFF
--- a/lib/mix/scan_task.ex
+++ b/lib/mix/scan_task.ex
@@ -1,9 +1,0 @@
-defmodule Mix.Tasks.Scan do
-  use Mix.Task
-
-  @shortdoc "Search for duplicates in the code"
-  @moduledoc @shortdoc
-  def run(_) do
-    Duplex.show_similar
-  end
-end

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,6 @@ defmodule Duplex.Mixfile do
   defp package do
     [
      name: :duplex,
-     # files: ["lib", "priv", "mix.exs", "README*", "readme*", "LICENSE*", "license*"],
      maintainers: ["Ivan Cherevko", "Andrew Koryagin"],
      licenses: ["Apache 2.0"],
      links: %{},

--- a/test/duplex_test.exs
+++ b/test/duplex_test.exs
@@ -4,39 +4,62 @@ defmodule DuplexTest do
   import Duplex
 
   test "getting all .ex, .exs files" do
-    assert Duplex.get_files("lib") == ["lib/mix/scan_task.ex", "lib/duplex.ex"]
+    assert Duplex.get_files("test") == ["test/test_helper.exs",
+                                        "test/files_for_tests/example_code4.ex",
+                                        "test/files_for_tests/example_code3.ex",
+                                        "test/files_for_tests/example_code2.ex",
+                                        "test/files_for_tests/example_code1.ex",
+                                        "test/duplex_test.exs"]
     assert Duplex.get_files("path_does_not_exist") == []
   end
 
-  test "_this app code_ has no duplicates" do
-    assert Duplex.show_similar == []
-  end
-
-  def get_nodes(threshold) do
+  def get_nodes(threshold, f_index \\ nil) do
     dir = "test/files_for_tests/"
     name = "example_code"
-    ext = ".txt"
-    files = ["#{dir}#{name}1#{ext}", "#{dir}#{name}2#{ext}", "#{dir}#{name}3#{ext}", "#{dir}#{name}4#{ext}"]
+    ext = ".ex"
+    f_names = ["#{dir}#{name}1#{ext}",
+               "#{dir}#{name}2#{ext}",
+               "#{dir}#{name}3#{ext}",
+               "#{dir}#{name}4#{ext}"]
+    files = if f_index do
+      Enum.slice(f_names, f_index..f_index)
+    else
+      f_names
+    end
     nodes = for file <- files do
       code_blocks(file, threshold)
     end
     nodes |> Enum.flat_map(&(&1))
   end
 
-  test "equal code groups" do
-    equals = [[{"test/files_for_tests/example_code1.txt", {1, 11}, 12},
-               {"test/files_for_tests/example_code2.txt", {1, 11}, 12},
-               {"test/files_for_tests/example_code4.txt", {2, 12}, 12}]]
+  test "example_code duplicates" do
+    results = [[{"test/files_for_tests/example_code1.ex", {1, 14}, 13},
+                {"test/files_for_tests/example_code2.ex", {1, 14}, 13},
+                {"test/files_for_tests/example_code4.ex", {2, 16}, 13}]]
+    f_name = "test_res.txt"
+    dir = ["test/files_for_tests"]
+    assert Duplex.show_similar(dir, nil, nil, f_name) == results
+    assert Duplex.show_similar(dir, 20, nil, f_name) == results
+    assert File.rm(f_name) == :ok
+  end
 
-    nodes = get_nodes(7)
-    assert Duplex.equal_code(nodes) == equals
+  test "async works the same" do
+    f_name = "test_res.txt"
+    dir = ["test/files_for_tests"]
+    four_th = Duplex.show_similar(dir, nil, 4, f_name)
+    one_th = Duplex.show_similar(dir, nil, 1, f_name)
+    assert four_th == one_th
+    assert File.rm(f_name) == :ok
   end
 
   test "async file reading" do
     dir = "test/files_for_tests/"
     name = "example_code"
-    ext = ".txt"
-    files = ["#{dir}#{name}1#{ext}", "#{dir}#{name}2#{ext}", "#{dir}#{name}3#{ext}", "#{dir}#{name}4#{ext}"]
+    ext = ".ex"
+    files = ["#{dir}#{name}1#{ext}",
+             "#{dir}#{name}2#{ext}",
+             "#{dir}#{name}3#{ext}",
+             "#{dir}#{name}4#{ext}"]
     chunks = for i <- 1..8 do
       Duplex.read_files(files, i, 7)
     end
@@ -44,13 +67,9 @@ defmodule DuplexTest do
   end
 
   test "shape hashes" do
-    dir = "test/files_for_tests/"
-    name = "example_code"
-    ext = ".txt"
-    files = ["#{dir}#{name}1#{ext}", "#{dir}#{name}2#{ext}", "#{dir}#{name}3#{ext}"]
-    [nodes1, nodes2, nodes3] = for file <- files do
-      code_blocks(file, 7)
-    end
+    nodes1 = get_nodes(7, 0)
+    nodes2 = get_nodes(7, 1)
+    nodes3 = get_nodes(7, 2)
     {_, shape1} = nodes1 |> Enum.max_by(fn {_, shape} -> shape[:depth] end)
     {_, shape2} = nodes2 |> Enum.max_by(fn {_, shape} -> shape[:depth] end)
     {_, shape3} = nodes3 |> Enum.max_by(fn {_, shape} -> shape[:depth] end)
@@ -59,6 +78,29 @@ defmodule DuplexTest do
     h3 = shape3 |> Duplex.hash_shape
     assert h1 == h2
     assert h1 != h3
+  end
+
+  test "argparse" do
+    args = ["--help", "--njobs", "10",
+            "--threshold", "2", "--file",
+            "/path/to/file.ex"]
+    assert Duplex.parse_args(args) == {true, 2, 10, "/path/to/file.ex"}
+  end
+
+  test "this app has no duplicates" do
+    assert Duplex.main(["lib"]) == []
+  end
+
+  test "escript" do
+    assert Duplex.main(["--help"]) == Duplex.help_text
+    assert Duplex.main == Duplex.show_similar
+  end
+
+  test "writting file" do
+    f_name = "f.ex"
+    assert Duplex.write_file(f_name, ["data1", "data2"]) == :ok
+    assert File.read!(f_name) == "data1\ndata2\n"
+    assert File.rm(f_name) == :ok
   end
 
 end

--- a/test/files_for_tests/example_code1.ex
+++ b/test/files_for_tests/example_code1.ex
@@ -1,4 +1,7 @@
 defmodule M1 do
+  @moduledoc """
+    M1
+  """
   def f(a, b) do
     if b != 0 do
        if a > b do

--- a/test/files_for_tests/example_code2.ex
+++ b/test/files_for_tests/example_code2.ex
@@ -1,4 +1,7 @@
-defmodule M2 do
+ defmodule M2 do
+  @moduledoc """
+    M2
+  """
   def f(n, m) do
     if m != 0 do
        if n > m do

--- a/test/files_for_tests/example_code3.ex
+++ b/test/files_for_tests/example_code3.ex
@@ -1,4 +1,7 @@
 defmodule M3 do
+  @moduledoc """
+    M3
+  """
   def f(n, m) do
     n + m
   end

--- a/test/files_for_tests/example_code4.ex
+++ b/test/files_for_tests/example_code4.ex
@@ -1,15 +1,22 @@
 
 defmodule M4 do
+  @moduledoc """
+    M4
+  """
   def f(a, b) do
     if b != 0 do
        if a > b do
            a = a - b
        else
            b = b - a
+       # 1
        end
        f(a, b)
     else
        a
+    # 2
     end
+  # 3
   end
+# 4
 end


### PR DESCRIPTION
credo/dogma - clear
test coverage 96.8%:
Uncovered only 2 lines:
1)` def show_similar(dirs \\ nil, t_hold \\ nil, n_jobs \\ nil, export \\ nil) do` -- how should I cover this? try all combinations?))
2) IO.puts item -- uncovered because it pollutes output during the tests