### PR TITLE
Add mix task for #6

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ mix deps.get
 
 ## Usage as dependency
 
-```elixir
-iex -S mix
-Duplex.show_similar
+```
+mix duplex
+```
+
+or with arguments
+
+```
+mix duplex --threshold 7
 ```
 
 ## Config

--- a/lib/mix/duplex.ex
+++ b/lib/mix/duplex.ex
@@ -1,0 +1,7 @@
+defmodule Mix.Tasks.Duplex do
+  use Mix.Task
+
+  def run(args) do
+    Duplex.main(args)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Duplex.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [applications: [:logger], extra_applications: [:dir_walker]]
   end
 
   def escript do

--- a/mix.exs
+++ b/mix.exs
@@ -2,16 +2,18 @@ defmodule Duplex.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :duplex,
-     version: "0.1.1",
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     test_coverage: [tool: Coverex.Task],
-     deps: deps(),
-     escript: escript()]
+    [
+      app: :duplex,
+      version: "0.1.1",
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      test_coverage: [tool: Coverex.Task],
+      deps: deps(),
+      escript: escript()
+    ]
   end
 
   def application do
@@ -53,11 +55,10 @@ defmodule Duplex.Mixfile do
 
   defp package do
     [
-     name: :duplex,
-     maintainers: ["Ivan Cherevko", "Andrew Koryagin"],
-     licenses: ["Apache 2.0"],
-     links: %{},
+      name: :duplex,
+      maintainers: ["Ivan Cherevko", "Andrew Koryagin"],
+      licenses: ["Apache 2.0"],
+      links: %{}
     ]
   end
-
 end

--- a/test/duplex_test.exs
+++ b/test/duplex_test.exs
@@ -4,12 +4,15 @@ defmodule DuplexTest do
   import Duplex
 
   test "getting all .ex, .exs files" do
-    assert Duplex.get_files("test") == ["test/test_helper.exs",
-                                        "test/files_for_tests/example_code4.ex",
-                                        "test/files_for_tests/example_code3.ex",
-                                        "test/files_for_tests/example_code2.ex",
-                                        "test/files_for_tests/example_code1.ex",
-                                        "test/duplex_test.exs"]
+    assert Duplex.get_files("test") == [
+             "test/test_helper.exs",
+             "test/files_for_tests/example_code4.ex",
+             "test/files_for_tests/example_code3.ex",
+             "test/files_for_tests/example_code2.ex",
+             "test/files_for_tests/example_code1.ex",
+             "test/duplex_test.exs"
+           ]
+
     assert Duplex.get_files("path_does_not_exist") == []
   end
 
@@ -17,25 +20,38 @@ defmodule DuplexTest do
     dir = "test/files_for_tests/"
     name = "example_code"
     ext = ".ex"
-    f_names = ["#{dir}#{name}1#{ext}",
-               "#{dir}#{name}2#{ext}",
-               "#{dir}#{name}3#{ext}",
-               "#{dir}#{name}4#{ext}"]
-    files = if f_index do
-      Enum.slice(f_names, f_index..f_index)
-    else
-      f_names
-    end
-    nodes = for file <- files do
-      code_blocks(file, threshold)
-    end
-    nodes |> Enum.flat_map(&(&1))
+
+    f_names = [
+      "#{dir}#{name}1#{ext}",
+      "#{dir}#{name}2#{ext}",
+      "#{dir}#{name}3#{ext}",
+      "#{dir}#{name}4#{ext}"
+    ]
+
+    files =
+      if f_index do
+        Enum.slice(f_names, f_index..f_index)
+      else
+        f_names
+      end
+
+    nodes =
+      for file <- files do
+        code_blocks(file, threshold)
+      end
+
+    nodes |> Enum.flat_map(& &1)
   end
 
   test "example_code duplicates" do
-    results = [[{"test/files_for_tests/example_code1.ex", {1, 14}, 13},
-                {"test/files_for_tests/example_code2.ex", {1, 14}, 13},
-                {"test/files_for_tests/example_code4.ex", {2, 16}, 13}]]
+    results = [
+      [
+        {"test/files_for_tests/example_code1.ex", {1, 14}, 13},
+        {"test/files_for_tests/example_code2.ex", {1, 14}, 13},
+        {"test/files_for_tests/example_code4.ex", {2, 16}, 13}
+      ]
+    ]
+
     f_name = "test_res.txt"
     dir = ["test/files_for_tests"]
     assert Duplex.show_similar(dir, nil, nil, f_name) == results
@@ -56,14 +72,20 @@ defmodule DuplexTest do
     dir = "test/files_for_tests/"
     name = "example_code"
     ext = ".ex"
-    files = ["#{dir}#{name}1#{ext}",
-             "#{dir}#{name}2#{ext}",
-             "#{dir}#{name}3#{ext}",
-             "#{dir}#{name}4#{ext}"]
-    chunks = for i <- 1..8 do
-      Duplex.read_files(files, i, 7)
-    end
-    assert chunks |> Enum.uniq |> length == 1
+
+    files = [
+      "#{dir}#{name}1#{ext}",
+      "#{dir}#{name}2#{ext}",
+      "#{dir}#{name}3#{ext}",
+      "#{dir}#{name}4#{ext}"
+    ]
+
+    chunks =
+      for i <- 1..8 do
+        Duplex.read_files(files, i, 7)
+      end
+
+    assert chunks |> Enum.uniq() |> length == 1
   end
 
   test "shape hashes" do
@@ -73,17 +95,15 @@ defmodule DuplexTest do
     {_, shape1} = nodes1 |> Enum.max_by(fn {_, shape} -> shape[:depth] end)
     {_, shape2} = nodes2 |> Enum.max_by(fn {_, shape} -> shape[:depth] end)
     {_, shape3} = nodes3 |> Enum.max_by(fn {_, shape} -> shape[:depth] end)
-    h1 = shape1 |> Duplex.hash_shape
-    h2 = shape2 |> Duplex.hash_shape
-    h3 = shape3 |> Duplex.hash_shape
+    h1 = shape1 |> Duplex.hash_shape()
+    h2 = shape2 |> Duplex.hash_shape()
+    h3 = shape3 |> Duplex.hash_shape()
     assert h1 == h2
     assert h1 != h3
   end
 
   test "argparse" do
-    args = ["--help", "--njobs", "10",
-            "--threshold", "2", "--file",
-            "/path/to/file.ex"]
+    args = ["--help", "--njobs", "10", "--threshold", "2", "--file", "/path/to/file.ex"]
     assert Duplex.parse_args(args) == {true, 2, 10, "/path/to/file.ex"}
   end
 
@@ -92,8 +112,8 @@ defmodule DuplexTest do
   end
 
   test "escript" do
-    assert Duplex.main(["--help"]) == Duplex.help_text
-    assert Duplex.main == Duplex.show_similar
+    assert Duplex.main(["--help"]) == Duplex.help_text()
+    assert Duplex.main() == Duplex.show_similar()
   end
 
   test "writting file" do
@@ -102,5 +122,4 @@ defmodule DuplexTest do
     assert File.read!(f_name) == "data1\ndata2\n"
     assert File.rm(f_name) == :ok
   end
-
 end

--- a/test/files_for_tests/example_code1.ex
+++ b/test/files_for_tests/example_code1.ex
@@ -4,14 +4,15 @@ defmodule M1 do
   """
   def f(a, b) do
     if b != 0 do
-       if a > b do
-           a = a - b
-       else
-           b = b - a
-       end
-       f(a, b)
+      if a > b do
+        a = a - b
+      else
+        b = b - a
+      end
+
+      f(a, b)
     else
-       a
+      a
     end
   end
 end

--- a/test/files_for_tests/example_code2.ex
+++ b/test/files_for_tests/example_code2.ex
@@ -1,17 +1,18 @@
- defmodule M2 do
+defmodule M2 do
   @moduledoc """
     M2
   """
   def f(n, m) do
     if m != 0 do
-       if n > m do
-           n = n - m
-       else
-           m = m - n
-       end
-       f(n, m)
+      if n > m do
+        n = n - m
+      else
+        m = m - n
+      end
+
+      f(n, m)
     else
-       n
+      n
     end
   end
 end

--- a/test/files_for_tests/example_code4.ex
+++ b/test/files_for_tests/example_code4.ex
@@ -1,22 +1,24 @@
-
 defmodule M4 do
   @moduledoc """
     M4
   """
   def f(a, b) do
     if b != 0 do
-       if a > b do
-           a = a - b
-       else
-           b = b - a
-       # 1
-       end
-       f(a, b)
+      if a > b do
+        a = a - b
+      else
+        b = b - a
+        # 1
+      end
+
+      f(a, b)
     else
-       a
-    # 2
+      a
+      # 2
     end
-  # 3
+
+    # 3
   end
-# 4
+
+  # 4
 end


### PR DESCRIPTION
This pull request has three commits:

1) Adding a mix task so this can be used as `mix duplex --threshold 7` and similar
2) Updates OptionParser usage and 'function_call' vs 'function_call()' to remove warnings with newer elixir versions
3) Largest commit applies `mix format` to the source tree to use elixir standard formatting

If you like we can split that up.

@junk2112 